### PR TITLE
[RCA-54] Finish delegate method reporting from RVIRemoteNode to calling application

### DIFF
--- a/rvi/src/main/java/com/jaguarlandrover/rvi/DlinkPacketParser.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/DlinkPacketParser.java
@@ -47,7 +47,7 @@ class DlinkPacketParser
          *
          * @param error the error
          */
-        void onPacketFailedToParse(Throwable error);
+        void onPacketFailedToParse(DlinkPacket packet, Throwable error);
     }
 
     /**
@@ -114,7 +114,7 @@ class DlinkPacketParser
             ((DlinkPacketParserTestCaseListener) mDataParserListener).onJsonStringParsed(string);
 
         Gson gson = new Gson();
-        DlinkPacket packet;
+        DlinkPacket packet = null;
 
         try {
             packet = gson.fromJson(string, DlinkPacket.class);
@@ -138,7 +138,7 @@ class DlinkPacketParser
             }
         } catch (Exception e) {
             e.printStackTrace();
-            mDataParserListener.onPacketFailedToParse(e);
+            mDataParserListener.onPacketFailedToParse(packet, e);
 
             return null;
         }

--- a/rvi/src/main/java/com/jaguarlandrover/rvi/RVIRemoteNode.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/RVIRemoteNode.java
@@ -34,8 +34,6 @@ public class RVIRemoteNode implements RVILocalNode.LocalNodeListener
 
     private RemoteConnectionManager mRemoteConnectionManager = new RemoteConnectionManager();
 
-    private boolean mIsConnected = false;
-
     private HashMap<String, Service> mAuthorizedRemoteServices = new HashMap<>();
     private HashMap<String, Service> mAuthorizedLocalServices  = new HashMap<>();
 
@@ -49,6 +47,16 @@ public class RVIRemoteNode implements RVILocalNode.LocalNodeListener
     private Integer mRemotePort;
     private String  mRemoteAddr;
 
+    private State mState;
+
+    public enum State
+    {
+        CONNECTING,
+        CONNECTED,
+        DISCONNECTING,
+        DISCONNECTED
+    }
+
     public RVIRemoteNode(Context context) {
         mRemoteConnectionManager.setListener(new RemoteConnectionManagerListener()
         {
@@ -58,8 +66,10 @@ public class RVIRemoteNode implements RVILocalNode.LocalNodeListener
 
                 openConnection();
 
-                mIsConnected = true;
-                if (mListener != null) mListener.nodeDidConnect(RVIRemoteNode.this);
+                if (mState != State.CONNECTED) {
+                    mState = State.CONNECTED;
+                    if (mListener != null) mListener.nodeDidConnect(RVIRemoteNode.this);
+                }
 
                 validateLocalCredentials();
                 authorizeNode();
@@ -71,8 +81,10 @@ public class RVIRemoteNode implements RVILocalNode.LocalNodeListener
 
                 closeConnection();
 
-                mIsConnected = false;
-                if (mListener != null) mListener.nodeDidFailToConnect(RVIRemoteNode.this, error);
+                if (mState != State.DISCONNECTED) {
+                    mState = State.DISCONNECTED;
+                    if (mListener != null) mListener.nodeDidFailToConnect(RVIRemoteNode.this, error);
+                }
             }
 
             @Override
@@ -81,15 +93,15 @@ public class RVIRemoteNode implements RVILocalNode.LocalNodeListener
 
                 closeConnection();
 
-                mIsConnected = false;
-                if (mListener != null) mListener.nodeDidDisconnect(RVIRemoteNode.this, trigger);
+                if (mState != State.DISCONNECTED) {
+                    mState = State.DISCONNECTED;
+                    if (mListener != null) mListener.nodeDidDisconnect(RVIRemoteNode.this, trigger);
+                }
             }
 
             @Override
             public void onRVIDidReceivePacket(DlinkPacket packet) {
                 if (packet == null) return;
-
-                //Log.d(TAG, Util.getMethodName() + ": " + packet.getClass().toString());
 
                 if (packet.getClass().equals(DlinkReceivePacket.class)) {
                     handleReceivePacket((DlinkReceivePacket) packet);
@@ -186,13 +198,15 @@ public class RVIRemoteNode implements RVILocalNode.LocalNodeListener
     }
 
     public boolean isConnected() {
-        return mIsConnected;
+        return mState == State.CONNECTED;
     }
 
     /**
      * Tells the local RVI node to connect to the remote RVI node, letting the RVINode choose the best connection.
      */
     public void connect() {
+        mState = State.CONNECTING;
+
         mRemoteConnectionManager.setKeyStores(RVILocalNode.getServerKeyStore(), RVILocalNode.getDeviceKeyStore(), RVILocalNode.getDeviceKeyStorePassword());
         mRemoteConnectionManager.connect();
     }
@@ -201,7 +215,13 @@ public class RVIRemoteNode implements RVILocalNode.LocalNodeListener
      * Tells the local RVI node to disconnect all connections to the remote RVI node.
      */
     public void disconnect() {
+        mState = State.DISCONNECTING;
+
         mRemoteConnectionManager.disconnect();
+    }
+
+    public State getState() {
+        return mState;
     }
 
     /**

--- a/rvi/src/main/java/com/jaguarlandrover/rvi/RemoteConnectionManager.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/RemoteConnectionManager.java
@@ -45,8 +45,8 @@ public class RemoteConnectionManager
             }
 
             @Override
-            public void onPacketFailedToParse(Throwable error) {
-                if (mListener != null) mListener.onRVIDidFailToReceivePacket(error);
+            public void onPacketFailedToParse(DlinkPacket packet, Throwable error) {
+                if (mListener != null) mListener.onRVIDidFailToReceivePacket(packet, error);
             }
         });
 
@@ -79,7 +79,7 @@ public class RemoteConnectionManager
 
             @Override
             public void onDidFailToSendDataToRemoteConnection(Throwable error) {
-                if (mListener != null) mListener.onRVIDidFailToSendPacket(error);
+                if (mListener != null) mListener.onRVIDidFailToSendPacket(null, error);
             }
         };
 
@@ -121,11 +121,11 @@ public class RemoteConnectionManager
         Log.d(TAG, "SNDRVI(" + dlinkPacket.getType() + "): " + dlinkPacket.toJsonString());
 
         if (mRemoteConnection == null) {
-            if (mListener != null) mListener.onRVIDidFailToSendPacket(new Error("Interface not selected"));
+            if (mListener != null) mListener.onRVIDidFailToSendPacket(dlinkPacket, new Error("Interface not selected"));
         } else if (!mRemoteConnection.isConfigured()) {
-            if (mListener != null) mListener.onRVIDidFailToSendPacket(new Error("Interface not configured"));
+            if (mListener != null) mListener.onRVIDidFailToSendPacket(dlinkPacket, new Error("Interface not configured"));
         } else if (!mRemoteConnection.isConnected()) {
-            if (mListener != null) mListener.onRVIDidFailToSendPacket(new Error("Interface not connected"));
+            if (mListener != null) mListener.onRVIDidFailToSendPacket(dlinkPacket, new Error("Interface not connected"));
         } else {
             mRemoteConnection.sendRviRequest(dlinkPacket);
         }

--- a/rvi/src/main/java/com/jaguarlandrover/rvi/RemoteConnectionManagerListener.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/RemoteConnectionManagerListener.java
@@ -48,7 +48,7 @@ interface RemoteConnectionManagerListener // TODO: Get rid of this middle man
      *
      * @param error the error
      */
-    void onRVIDidFailToReceivePacket(Throwable error);
+    void onRVIDidFailToReceivePacket(DlinkPacket packet, Throwable error);
 
     /**
      * On RVI did send packet.
@@ -60,5 +60,5 @@ interface RemoteConnectionManagerListener // TODO: Get rid of this middle man
      *
      * @param error the error
      */
-    void onRVIDidFailToSendPacket(Throwable error);
+    void onRVIDidFailToSendPacket(DlinkPacket packet, Throwable error);
 }

--- a/rvi/src/main/java/com/jaguarlandrover/rvi/ServerConnection.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/ServerConnection.java
@@ -85,7 +85,7 @@ class ServerConnection implements RemoteConnectionInterface
             e.printStackTrace();
         }
 
-        if (mRemoteConnectionListener != null && trigger != null) mRemoteConnectionListener.onRemoteConnectionDidDisconnect(trigger);
+        if (mRemoteConnectionListener != null /*&& trigger != null*/) mRemoteConnectionListener.onRemoteConnectionDidDisconnect(trigger);
     }
 
     @Override
@@ -150,8 +150,6 @@ class ServerConnection implements RemoteConnectionInterface
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-
-
 
                 Log.d(TAG, "Creating socket factory");
 

--- a/rvi/src/main/java/com/jaguarlandrover/rvi/Service.java
+++ b/rvi/src/main/java/com/jaguarlandrover/rvi/Service.java
@@ -190,7 +190,7 @@ class Service
      *
      * @return the service identifier
      */
-    String getServiceIdentifier() {
+    String  getServiceIdentifier() {
         if (shouldParseServiceName())
             parseFullyQualifiedServiceName();
 


### PR DESCRIPTION
Fix the issue with the disconnect delegate method not getting called so that there is that weird bug where other stuff is allowed to happen before remote connection is cleaned up.
Connect all the delegate methods through the layers of the rvi sdk to the api level.
