### PR TITLE
[RCA-61] Renamed the pki server request/response data objects to use the prefix 'PS' instead of 'PKI'.

### DIFF
--- a/app/src/main/java/com/jaguarlandrover/auto/remote/vehicleentry/LoginActivity.java
+++ b/app/src/main/java/com/jaguarlandrover/auto/remote/vehicleentry/LoginActivity.java
@@ -13,11 +13,11 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
-import com.jaguarlandrover.pki.PKICertificateResponse;
-import com.jaguarlandrover.pki.PKICertificateSigningRequestRequest;
+import com.jaguarlandrover.pki.PSCertificateResponse;
+import com.jaguarlandrover.pki.PSCertificateSigningRequestRequest;
 import com.jaguarlandrover.pki.PKIManager;
-import com.jaguarlandrover.pki.PKIServerResponse;
-import com.jaguarlandrover.pki.PKITokenVerificationRequest;
+import com.jaguarlandrover.pki.ProvisioningServerResponse;
+import com.jaguarlandrover.pki.PSTokenVerificationRequest;
 import com.jaguarlandrover.rvi.RVILocalNode;
 
 import java.security.KeyStore;
@@ -85,7 +85,7 @@ public class LoginActivity extends ActionBarActivity implements LoginActivityFra
 
                 mValidatingToken = true;
 
-                PKITokenVerificationRequest request = new PKITokenVerificationRequest(token, certId);
+                PSTokenVerificationRequest request = new PSTokenVerificationRequest(token, certId);
 
                 Log.d(TAG, "Sending token verification request: " + request.toString());
 
@@ -127,8 +127,8 @@ public class LoginActivity extends ActionBarActivity implements LoginActivityFra
 
     private PKIManager.ProvisioningServerListener mProvisioningServerListener = new PKIManager.ProvisioningServerListener() {
         @Override
-        public void managerDidReceiveResponseFromServer(PKIServerResponse response) {
-            if (response.getStatus() == PKIServerResponse.Status.VERIFICATION_NEEDED) {
+        public void managerDidReceiveResponseFromServer(ProvisioningServerResponse response) {
+            if (response.getStatus() == ProvisioningServerResponse.Status.VERIFICATION_NEEDED) {
                 mValidatingToken = true;
                 mAllValidCertsAcquired = false;
 
@@ -139,7 +139,7 @@ public class LoginActivity extends ActionBarActivity implements LoginActivityFra
                 mLoginActivityFragment.setHasKeys(true);
                 mLoginActivityFragment.setHasSignedCerts(false);
 
-            } else if (response.getStatus() == PKIServerResponse.Status.CERTIFICATE_RESPONSE) {
+            } else if (response.getStatus() == ProvisioningServerResponse.Status.CERTIFICATE_RESPONSE) {
                 Log.d(TAG, "Got server stuff, trying to connect");
 
                 mValidatingToken = false;
@@ -148,11 +148,11 @@ public class LoginActivity extends ActionBarActivity implements LoginActivityFra
                 mLoginActivityFragment.setHasKeys(true);
                 mLoginActivityFragment.setHasSignedCerts(true);
 
-                PKICertificateResponse certificateResponse = (PKICertificateResponse) response;
+                PSCertificateResponse certificateResponse = (PSCertificateResponse) response;
 
                 setUpRviAndConnectToServer(certificateResponse.getServerKeyStore(), certificateResponse.getDeviceKeyStore(), null, certificateResponse.getJwtCredentials());
                 launchLockActivityWhenReady();
-            } else if (response.getStatus() == PKIServerResponse.Status.ERROR) {
+            } else if (response.getStatus() == ProvisioningServerResponse.Status.ERROR) {
 
                 mLoginActivityFragment.setHasKeys(true);
                 mLoginActivityFragment.setHasSignedCerts(false);
@@ -186,7 +186,7 @@ public class LoginActivity extends ActionBarActivity implements LoginActivityFra
             SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(LoginActivity.this);
             String provisioningServerUrl = "http://" + preferences.getString("pref_provisioning_server_url", "38.129.64.40") + ":" + preferences.getString("pref_provisioning_server_port", "8000");
 
-            PKICertificateSigningRequestRequest request = new PKICertificateSigningRequestRequest(certificateSigningRequest);
+            PSCertificateSigningRequestRequest request = new PSCertificateSigningRequestRequest(certificateSigningRequest);
 
             PKIManager.sendCertificateSigningRequest(LoginActivity.this, mProvisioningServerListener, provisioningServerUrl, DEFAULT_PROVISIONING_SERVER_CSR_URL, request);
         }

--- a/pki/src/main/java/com/jaguarlandrover/pki/KeyStoreInterface.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/KeyStoreInterface.java
@@ -7,7 +7,7 @@ package com.jaguarlandrover.pki;
  * Mozilla Public License, version 2.0. The full text of the
  * Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
  *
- * File:    KeyManager.java
+ * File:    KeyStoreInterface.java
  * Project: UnlockDemo
  *
  * Created by Lilli Szafranski on 8/8/16.
@@ -65,7 +65,7 @@ import javax.security.auth.x500.X500Principal;
 /* Code from here: http://stackoverflow.com/a/37898553 */
 class KeyStoreInterface
 {
-    private final static String TAG = "PKI/KeyStoreManager____";
+    private final static String TAG = "PKI/KeyStoreInterface__";
 
     private final static String KEYSTORE_CLIENT_ALIAS = "RVI_CLIENT_KEYSTORE_ALIAS";
     private final static String KEYSTORE_SERVER_ALIAS = "RVI_SERVER_KEYSTORE_ALIAS";

--- a/pki/src/main/java/com/jaguarlandrover/pki/PKIManager.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/PKIManager.java
@@ -7,7 +7,7 @@ package com.jaguarlandrover.pki;
  * Mozilla Public License, version 2.0. The full text of the
  * Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
  *
- * File:    ProvisioningServerInterface.java
+ * File:    PKIManager.java
  * Project: UnlockDemo
  *
  * Created by Lilli Szafranski on 8/9/16.
@@ -32,7 +32,7 @@ public class PKIManager
      */
     public interface ProvisioningServerListener
     {
-        void managerDidReceiveResponseFromServer(PKIServerResponse response);
+        void managerDidReceiveResponseFromServer(ProvisioningServerResponse response);
     }
 
     public interface CertificateSigningRequestGeneratorListener
@@ -46,11 +46,11 @@ public class PKIManager
         KeyStoreInterface.generateKeyPairAndCertificateSigningRequest(context, listener, startDate, endDate, principalFormatterPattern, principalFormatterArgs);
     }
 
-    public static void sendCertificateSigningRequest(Context context, PKIManager.ProvisioningServerListener listener, String baseUrl, String requestUrl, PKIServerRequest certificateSigningRequest) {
+    public static void sendCertificateSigningRequest(Context context, PKIManager.ProvisioningServerListener listener, String baseUrl, String requestUrl, ProvisioningServerRequest certificateSigningRequest) {
         BackendServerInterface.sendProvisioningServerRequest(context, listener, baseUrl, requestUrl, certificateSigningRequest);
     }
 
-    public static void sendTokenVerificationRequest(Context context, PKIManager.ProvisioningServerListener listener, String baseUrl, String requestUrl, PKIServerRequest tokenVerificationRequest) {
+    public static void sendTokenVerificationRequest(Context context, PKIManager.ProvisioningServerListener listener, String baseUrl, String requestUrl, ProvisioningServerRequest tokenVerificationRequest) {
         BackendServerInterface.sendProvisioningServerRequest(context, listener, baseUrl, requestUrl, tokenVerificationRequest);
     }
 

--- a/pki/src/main/java/com/jaguarlandrover/pki/PSCertificateResponse.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/PSCertificateResponse.java
@@ -7,7 +7,7 @@ package com.jaguarlandrover.pki;
  * Mozilla Public License, version 2.0. The full text of the
  * Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
  *
- * File:    CertificateResponse.java
+ * File:    PSCertificateResponse.java
  * Project: UnlockDemo
  *
  * Created by Lilli Szafranski on 10/13/16.
@@ -19,7 +19,7 @@ import com.google.gson.annotations.SerializedName;
 import java.security.KeyStore;
 import java.util.ArrayList;
 
-public class PKICertificateResponse extends PKIServerResponse
+public class PSCertificateResponse extends ProvisioningServerResponse
 {
     @SerializedName("signed_certificate")
     private String mDeviceCertificate;
@@ -34,7 +34,7 @@ public class PKICertificateResponse extends PKIServerResponse
 
     private transient KeyStore mDeviceKeyStore;
 
-    public PKICertificateResponse() {
+    public PSCertificateResponse() {
     }
 
     String getDeviceCertificate() {

--- a/pki/src/main/java/com/jaguarlandrover/pki/PSCertificateSigningRequestRequest.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/PSCertificateSigningRequestRequest.java
@@ -7,7 +7,7 @@ package com.jaguarlandrover.pki;
  * Mozilla Public License, version 2.0. The full text of the
  * Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
  *
- * File:    CertificateSigningRequest.java
+ * File:    PSCertificateSigningRequestRequest.java
  * Project: UnlockDemo
  *
  * Created by Lilli Szafranski on 10/13/16.
@@ -16,15 +16,16 @@ package com.jaguarlandrover.pki;
 
 import com.google.gson.annotations.SerializedName;
 
-public class PKICertificateSigningRequestRequest extends PKIServerRequest {
+public class PSCertificateSigningRequestRequest extends ProvisioningServerRequest
+{
     @SerializedName("certificate_signing_request")
     private String mCertificateSigningRequest;
 
-    public PKICertificateSigningRequestRequest() {
+    public PSCertificateSigningRequestRequest() {
         setType(Type.CERTIFICATE_SIGNING_REQUEST);
     }
 
-    public PKICertificateSigningRequestRequest(String certificateSigningRequest) {
+    public PSCertificateSigningRequestRequest(String certificateSigningRequest) {
         setType(Type.CERTIFICATE_SIGNING_REQUEST);
 
         mCertificateSigningRequest = certificateSigningRequest;

--- a/pki/src/main/java/com/jaguarlandrover/pki/PSErrorResponse.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/PSErrorResponse.java
@@ -7,7 +7,7 @@ package com.jaguarlandrover.pki;
  * Mozilla Public License, version 2.0. The full text of the
  * Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
  *
- * File:    VerificationNeeded.java
+ * File:    PSErrorResponse.java
  * Project: UnlockDemo
  *
  * Created by Lilli Szafranski on 10/13/16.
@@ -16,15 +16,21 @@ package com.jaguarlandrover.pki;
 
 import com.google.gson.annotations.SerializedName;
 
-public class PKIVerificationNeededResponse extends PKIServerResponse
+public class PSErrorResponse extends ProvisioningServerResponse
 {
-    @SerializedName("message")
-    private String mMessage = "";
+    @SerializedName("reason")
+    private String mReason = "unknown";
 
-    public PKIVerificationNeededResponse() {
+    public PSErrorResponse() {
     }
 
-    public String getMessage() {
-        return mMessage;
+    PSErrorResponse(String reason) {
+        setStatus("error");
+
+        mReason = reason;
+    }
+
+    public String getReason() {
+        return mReason;
     }
 }

--- a/pki/src/main/java/com/jaguarlandrover/pki/PSTokenVerificationRequest.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/PSTokenVerificationRequest.java
@@ -7,7 +7,7 @@ package com.jaguarlandrover.pki;
  * Mozilla Public License, version 2.0. The full text of the
  * Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
  *
- * File:    TokenVerification.java
+ * File:    PSTokenVerificationRequest.java
  * Project: UnlockDemo
  *
  * Created by Lilli Szafranski on 10/13/16.
@@ -16,7 +16,8 @@ package com.jaguarlandrover.pki;
 
 import com.google.gson.annotations.SerializedName;
 
-public class PKITokenVerificationRequest extends PKIServerRequest {
+public class PSTokenVerificationRequest extends ProvisioningServerRequest
+{
     private transient String mToken = "";
 
     private transient String mCertificateId = "";
@@ -24,11 +25,11 @@ public class PKITokenVerificationRequest extends PKIServerRequest {
     @SerializedName("jwt")
     private String jwt = null;
 
-    public PKITokenVerificationRequest() {
+    public PSTokenVerificationRequest() {
         setType(Type.TOKEN_VERIFICATION);
     }
 
-    public PKITokenVerificationRequest(String token, String certificateId) {
+    public PSTokenVerificationRequest(String token, String certificateId) {
         setType(Type.TOKEN_VERIFICATION);
 
         mToken = token;

--- a/pki/src/main/java/com/jaguarlandrover/pki/PSVerificationNeededResponse.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/PSVerificationNeededResponse.java
@@ -7,7 +7,7 @@ package com.jaguarlandrover.pki;
  * Mozilla Public License, version 2.0. The full text of the
  * Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
  *
- * File:    Error.java
+ * File:    PSVerificationNeededResponse.java
  * Project: UnlockDemo
  *
  * Created by Lilli Szafranski on 10/13/16.
@@ -16,21 +16,15 @@ package com.jaguarlandrover.pki;
 
 import com.google.gson.annotations.SerializedName;
 
-public class PKIErrorResponse extends PKIServerResponse
+public class PSVerificationNeededResponse extends ProvisioningServerResponse
 {
-    @SerializedName("reason")
-    private String mReason = "unknown";
+    @SerializedName("message")
+    private String mMessage = "";
 
-    public PKIErrorResponse() {
+    public PSVerificationNeededResponse() {
     }
 
-    PKIErrorResponse(String reason) {
-        setStatus("error");
-
-        mReason = reason;
-    }
-
-    public String getReason() {
-        return mReason;
+    public String getMessage() {
+        return mMessage;
     }
 }

--- a/pki/src/main/java/com/jaguarlandrover/pki/ProvisioningServerRequest.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/ProvisioningServerRequest.java
@@ -16,8 +16,8 @@ package com.jaguarlandrover.pki;
 
 import com.google.gson.annotations.SerializedName;
 
-public class PKIServerRequest {
-    private final static String TAG = "UnlockDemo/ProvSrvrReq_";
+public class ProvisioningServerRequest {
+    private final static String TAG = "PKI/ProvServerRequest__";
 
     @SerializedName("type")
     private String mType = "undefined";
@@ -29,10 +29,10 @@ public class PKIServerRequest {
 
     }
 
-    public PKIServerRequest() {
+    public ProvisioningServerRequest() {
     }
 
-    public PKIServerRequest.Type getType() {
+    public ProvisioningServerRequest.Type getType() {
         switch (mType) {
             case "token_verification":
                 return Type.TOKEN_VERIFICATION;
@@ -43,7 +43,7 @@ public class PKIServerRequest {
         return Type.UNDEFINED;
     }
 
-    protected void setType(PKIServerRequest.Type type) {
+    protected void setType(ProvisioningServerRequest.Type type) {
         switch (type) {
             case UNDEFINED:
                 mType = "undefined";

--- a/pki/src/main/java/com/jaguarlandrover/pki/ProvisioningServerResponse.java
+++ b/pki/src/main/java/com/jaguarlandrover/pki/ProvisioningServerResponse.java
@@ -16,8 +16,8 @@ package com.jaguarlandrover.pki;
 
 import com.google.gson.annotations.SerializedName;
 
-public class PKIServerResponse {
-    private final static String TAG = "UnlockDemo/ProvSrvrResp";
+public class ProvisioningServerResponse {
+    private final static String TAG = "PKI/ProvServerResponse_";
 
     @SerializedName("status")
     private String mStatus = "unknown";
@@ -29,7 +29,7 @@ public class PKIServerResponse {
         CERTIFICATE_RESPONSE
     }
 
-    public PKIServerResponse() {
+    public ProvisioningServerResponse() {
     }
 
     public Status getStatus() {

--- a/rvitest/src/main/java/org/genivi/rvitest/MainActivity.java
+++ b/rvitest/src/main/java/org/genivi/rvitest/MainActivity.java
@@ -7,10 +7,10 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 
-import com.jaguarlandrover.pki.PKICertificateResponse;
-import com.jaguarlandrover.pki.PKICertificateSigningRequestRequest;
+import com.jaguarlandrover.pki.PSCertificateResponse;
+import com.jaguarlandrover.pki.PSCertificateSigningRequestRequest;
 import com.jaguarlandrover.pki.PKIManager;
-import com.jaguarlandrover.pki.PKIServerResponse;
+import com.jaguarlandrover.pki.ProvisioningServerResponse;
 import com.jaguarlandrover.rvi.RVILocalNode;
 
 import java.security.KeyStore;
@@ -84,22 +84,22 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void sendCertificateSigningRequest(String certificateSigningRequest) {
-        PKICertificateSigningRequestRequest request = new PKICertificateSigningRequestRequest(certificateSigningRequest);
+        PSCertificateSigningRequestRequest request = new PSCertificateSigningRequestRequest(certificateSigningRequest);
 
         PKIManager.sendCertificateSigningRequest(this, new PKIManager.ProvisioningServerListener() {
             @Override
-            public void managerDidReceiveResponseFromServer(PKIServerResponse response) {
-                if (response.getStatus() == PKIServerResponse.Status.VERIFICATION_NEEDED) {
+            public void managerDidReceiveResponseFromServer(ProvisioningServerResponse response) {
+                if (response.getStatus() == ProvisioningServerResponse.Status.VERIFICATION_NEEDED) {
                     Log.e(TAG, "Problem: verification needed...");
 
-                } else if (response.getStatus() == PKIServerResponse.Status.CERTIFICATE_RESPONSE) {
+                } else if (response.getStatus() == ProvisioningServerResponse.Status.CERTIFICATE_RESPONSE) {
                     Log.d(TAG, "Certificate signing request received and server sent back certs and creds.");
 
-                    PKICertificateResponse certificateResponse = (PKICertificateResponse) response;
+                    PSCertificateResponse certificateResponse = (PSCertificateResponse) response;
 
                     setUpRviAndConnectToServer(certificateResponse.getServerKeyStore(), certificateResponse.getDeviceKeyStore(), null, certificateResponse.getJwtCredentials());
 
-                } else if (response.getStatus() == PKIServerResponse.Status.ERROR) {
+                } else if (response.getStatus() == ProvisioningServerResponse.Status.ERROR) {
                     Log.e(TAG, "Error from server");
 
                 }


### PR DESCRIPTION
Renamed the server request/response classes 'ProvisioningServer...'. Fixed up the headers to reflect the names. Fixed up some of the TAGS.